### PR TITLE
Removed test fragment

### DIFF
--- a/ipk/data/opt/etc/dinit.d/test
+++ b/ipk/data/opt/etc/dinit.d/test
@@ -1,3 +1,0 @@
-type = process
-command = /system/bin/sleep 600
-restart = true


### PR DESCRIPTION
The test service is no longer needed since we now have enough real services that can be used for testing.